### PR TITLE
T5487 add support for bulk doc fetch

### DIFF
--- a/index.js
+++ b/index.js
@@ -288,7 +288,6 @@ function find(connectionName, collectionName, criteria, cb, round) {
     if (Array.isArray(id)) {
       // format the query into expected format
       var ids = { keys: id };
-      console.log('query', ids);
       // fetch maps to nano fetch_docs or fetchDocs depending on version
       db.fetch(ids, dbOptions, function(err, doc) {
         if (err) {

--- a/index.js
+++ b/index.js
@@ -289,15 +289,37 @@ function find(connectionName, collectionName, criteria, cb, round) {
       // format the query into expected format
       var ids = { keys: id };
       // fetch maps to nano fetch_docs or fetchDocs depending on version
-      db.fetch(ids, dbOptions, function(err, doc) {
+      db.fetch(ids, dbOptions, function(err, docs) {
         if (err) {
           if (err.status_code == 404) {
             return cb(null, []);
           }
           return cb(err);
         }
-        var docs = doc ? [doc] : [];
-        return cb(null, docs.map(docForReply));
+
+        // special mapping needed since docs is in format:
+        /*
+        {
+          total_rows: 123,
+          offset: 0,
+          rows: [
+            {
+              id: '',
+              key: '',
+              value: {},
+              doc: {}
+            }
+            ...
+          ]
+        }
+        */
+        var rows = docs.rows || [];
+        return cb(
+          null,
+          rows.map(function mapDocs(doc) {
+            return docForReply(doc.doc);
+          })
+        );
       });
       return;
     }


### PR DESCRIPTION
**External Reference:**
https://phab.hrt.io/T5487

**Problem:**
I would like to retrieve multiple user docs in a single request.

**Solution:**
Expose the `nano` bulk document fetch functionality when the following conditions are met:
- Search criteria contains ONLY one criteria
- Search criteria is for `id` or `_id`
- Search criteria parameter is an `Array` type

**Testing Steps:**
Tested this change in TMM by doing the following:
- npm link to my sails-couchdb-orm branch in TMM
- create a sample bulk call:
```javascript
User.findByIds = function *(ids, clean) {
  let result = yield tfy(User.find, User)({ _id: ids });
  return result;
};
```
- call that function and verify the results/perform a tcpdump

Request:
```bash
09:50:07.347737 IP 172.16.12.105.51383 > 5f4edf3b-b2d0-415c-afaf-aff3a5b44909.hrt.io.5984: Flags [.], seq 1:1257, ack 1, win 4121, options [nop,nop,TS val 778289323 ecr 4289747374], length 1256
....E...w.@.@..^...i
..D...`
.Y%..n...........
.c....Y.POST /user/_all_docs?include_docs=true HTTP/1.1
content-type: application/json
accept: application/json
host: couchdb.service.red.consul:5984
content-length: 1585
Connection: close

{"keys":["11f291782caef73e936d6cc33d1b562d","11f291782caef73e936d6cc33d35bfb8","8f6f4d7152ba8d5664a58d66dac3565f","5b83f83b399d6f3ab18d79338e7a11f4","5b83f83b399d6f3ab18d79338e7a344d","5b83f83b399d6f3ab18d79338e8ab0b8","5b83f83b399d6f3ab18d79338e901a29","5b83f83b399d6f3ab18d79338eced70e","5b83f83b399d6f3ab18d79338ecfcaa4","5b83f83b399d6f3ab18d79338ed72f7e","5b83f83b399d6f3ab18d79338ed7ac22","5b83f83b399d6f3ab18d79338ed834e2","70c247091334b6b4cb6f851bc4935d69","8f6f4d7152ba8d5664a58d66dac3565f","80a01388cdfdc98f25045de4d22124ac","80a01388cdfdc98f25045de4d22789c6","80a01388cdfdc98f25045de4d2307900","80a01388cdfdc98f25045de4d2380fef","80a01388cdfdc98f25045de4d2c45d87","80a01388cdfdc98f25045de4d2ce0534","80a01388cdfdc98f25045de4d2ce224e","a9a3c2ac289b2b8de82c5ca5951e6887","a9a3c2ac289b2b8de82c5ca5956121f2","c7034614819281316ee8ece0eb2a3b6f","c7034614819281316ee8ece0eba54704","c7034614819281316ee8ece0eba57624","c7034614819281316ee8ece0ebaf449c","e70bff45484ffdfe25d9890887174e3a","e70bff45484ffdfe25d98908875ad8a4","f5fbe85f76c7c7c708e3b452bad7cdbe","f5fbe85
09:50:07.347741 IP 172.16.12.105.51383 > 5f4edf3b-b2d0-415c-afaf-aff3a5b44909.hrt.io.5984: Flags [P.], seq 1257:1775, ack 1, win 4121, options [nop,nop,TS val 778289323 ecr 4289747374], length 518
```

Response:
```bash
09:50:07.392233 IP 172.16.12.105.51383 > 5f4edf3b-b2d0-415c-afaf-aff3a5b44909.hrt.io.5984: Flags [.], ack 223, win 4114, options [nop,nop,TS val 778289366 ecr 4289747419], length 0
....E..4l]@.@......i
..D...`
.G%..L...........
.c....Y.
09:50:07.392239 IP 5f4edf3b-b2d0-415c-afaf-aff3a5b44909.hrt.io.5984 > 172.16.12.105.51383: Flags [.], seq 223:1479, ack 1775, win 7536, options [nop,nop,TS val 4289747420 ecr 778289323], length 1256
....E.....@.=..c
..D...i.`..%..L
.G...p3......
..Y..c..29
{"total_rows":11390,"offset":0,"rows":[

d69
{"id":"11f291782caef73e936d6cc33d1b562d","key":"11f291782caef73e936d6cc33d1b562d","value":{"rev":"4-be69fc3ddd898510bad17691246375f7"},"doc":{"_id":"11f291782caef73e936d6cc33d1b562d","_rev":"4-be69fc3ddd898510bad17691246375f7","email":"lan.nguyen+115@hart.com","identity_id":null,"identity_score":null,"daily_step_goal":null,"email_notify":null,"email_verified":null,"idx_created":null,"groups":"[]","npp_individual":null,"providers":"[\"7d2db115e66661f752fca842ee07813a\"]","forms":null,"two_factor":null,"two_factor_code":null,"idx_error":null,"patient_id":null,"work_email":null,"work_email_verified":null,"first_name":"SHAUN","last_name":"ZZTEST","archived":null,"password":"$2a$08$/3B9ZFXJAD8e7gXg9JPHMe7vbAJh.COPMnJ4LSRT3I8A/q8iLv31m","birthdate":"5/10/1987","language":null,"race":null,"gender":null,"ethnicity":null,"ss":"1217","phonenumber_home":null,"phonenumber_mobile":null,"phonenumber_work":null,"phonenumber_work_extension":null,"address_street":null,"address_street2":null,"address_zip":null,"address_city":null,"address_state":null,"emergency_contact":null,"emergency_contact_relationship":null,"emergency_contact_phone":null,"emergency_contact_cellphone":null,"emergency_contact_work_ph
09:50:07.392281 IP 5f4edf3b-b2d0-415c-afaf-aff3a5b44909.hrt.io.5984 > 172.16.12.105.51383: Flags [.], seq 1479:2735, ack 1775, win 7536, options [nop,nop,TS val 4289747420 ecr 778289323], length 1256
....E.....@.=..b
..D...i.`..%..4
```

